### PR TITLE
Fix CSS not showing up on https://alexrosales123.github.io/

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -26,6 +26,7 @@ jobs:
     - run: npm ci
     - run: npm run build  
     - run: npm run export
+    - run: touch out/.nojekyll
     
     - name: Deploy to GitHub Pages
       # You may pin to the exact commit or the version.


### PR DESCRIPTION
GitHub Pages has some software called jekyll that was messing with our `_next` folder in the output. That's why the styling wasn't showing up on https://alexrosales123.github.io/.

I added a line in our GitHub Actions file to tell jekyll to leave us alone.

You should be able to click the green button below to merge this fix into your repository. It'll automatically start building and once it's done, your portfolio site should look how it's supposed to!

Any future changes you make (by editing `index.js` like we did yesterday and committing and pushing your changes) will automatically be built and deployed within a few minutes.

Comment below if you have any questions!

Adrian 